### PR TITLE
chore: change twitter to fedi link

### DIFF
--- a/app/src/main/res/layout/logon.xml
+++ b/app/src/main/res/layout/logon.xml
@@ -34,7 +34,7 @@
 		android:layout_height="wrap_content"
 		android:layout_marginTop="15dp"
 		android:autoLink="web"
-		android:text="@string/twitter"/>
+		android:text="@string/fediverse"/>
 
 	<!--<CheckBox android:id="@+id/check5g"
 		android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
 	<string name="Password">password</string>
 	<string name="Logon">Create connection entry</string>
 
-	<string name="twitter">https://twitter.com/c3noc</string>
+	<string name="fediverse">https://chaos.social/@c3noc</string>
 
 	<string name="c5ghz">This device supports the 5GHz band</string>
 	<string name="l5ghz">(Unfortunately, autodetecting 5GHz support is broken&#8230;)</string>


### PR DESCRIPTION
Since most communication regarding c3 events happens on fedi and not on twitter/X these days, I think we should update the link in the app.